### PR TITLE
Fix - Deploying docs on PR's targeting master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ script:
   - npm run test:prod
   - npm run build
 after_success:
-  - npm run deploy-docs
+  - test $TRAVIS_BRANCH = "master" && test $TRAVIS_PULL_REQUEST = "false" && npm run deploy-docs
   - npm run semantic-release


### PR DESCRIPTION
If a PR targets the master branch, travis will still deploy the docs.  Since `TRAVIS_BRANCH` is set
to master if the target is master.

fix #39