### PR TITLE
Add custom headers support

### DIFF
--- a/src/api/actions.ts
+++ b/src/api/actions.ts
@@ -30,10 +30,10 @@ export function postBuildActions(
   token: string,
   buildNumber: number,
   action: BuildAction,
-  { circleHost, ...vcs }: GitInfo & CircleOptions
+  { circleHost, customHeaders, ...vcs }: GitInfo & CircleOptions
 ): Promise<BuildActionResponse> {
   const url = `${createVcsUrl(vcs)}/${buildNumber}/${action}`;
-  return client(token, circleHost).post(url);
+  return client(token, circleHost, customHeaders).post(url);
 }
 
 /**
@@ -49,12 +49,13 @@ export function postTriggerNewBuild(
   token: string,
   {
     circleHost,
+    customHeaders,
     vcs,
     options: { branch = "", newBuildOptions = {} } = {}
   }: GitRequiredRequest
 ): Promise<TriggerBuildResponse> {
   const url = `${createVcsUrl(vcs)}${branch ? `/tree/${branch}` : ""}`;
-  return client(token, circleHost).post<TriggerBuildResponse>(
+  return client(token, circleHost, customHeaders).post<TriggerBuildResponse>(
     url,
     newBuildOptions
   );

--- a/src/api/artifacts.ts
+++ b/src/api/artifacts.ts
@@ -23,10 +23,10 @@ import { queryParams } from "../util";
 export function getBuildArtifacts(
   token: string,
   buildNumber: number,
-  { circleHost, ...vcs }: GitInfo & CircleOptions
+  { circleHost, customHeaders, ...vcs }: GitInfo & CircleOptions
 ): Promise<ArtifactResponse> {
   const url = `${createVcsUrl(vcs)}/${buildNumber}/artifacts`;
-  return client(token, circleHost).get<ArtifactResponse>(url);
+  return client(token, circleHost, customHeaders).get<ArtifactResponse>(url);
 }
 
 /**
@@ -44,12 +44,12 @@ export function getBuildArtifacts(
  */
 export function getLatestArtifacts(
   token: string,
-  { vcs, options = {}, circleHost }: GitRequiredRequest
+  { vcs, options = {}, circleHost, customHeaders }: GitRequiredRequest
 ): Promise<ArtifactResponse> {
   const { branch, filter } = options;
   const url = `${createVcsUrl(vcs)}/latest/artifacts${queryParams({
     branch,
-    filter
+    filter,
   })}`;
-  return client(token, circleHost).get<ArtifactResponse>(url);
+  return client(token, circleHost, customHeaders).get<ArtifactResponse>(url);
 }

--- a/src/api/builds.ts
+++ b/src/api/builds.ts
@@ -25,10 +25,12 @@ import { queryParams } from "../util";
  */
 export function getRecentBuilds(
   token: string,
-  { limit, offset, circleHost }: Options & CircleOptions = {}
+  { limit, offset, circleHost, customHeaders }: Options & CircleOptions = {}
 ): Promise<BuildSummaryResponse> {
   const url = `${API_RECENT_BUILDS}${queryParams({ limit, offset })}`;
-  return client(token, circleHost).get<BuildSummaryResponse>(url);
+  return client(token, circleHost, customHeaders).get<BuildSummaryResponse>(
+    url
+  );
 }
 
 /**
@@ -56,12 +58,14 @@ export function getRecentBuilds(
  */
 export function getBuildSummaries(
   token: string,
-  { vcs, options = {}, circleHost }: GitRequiredRequest
+  { vcs, options = {}, circleHost, customHeaders }: GitRequiredRequest
 ): Promise<BuildSummaryResponse> {
   const { limit, offset, filter, branch } = options;
   const url = `${createVcsUrl(vcs)}${branch ? `/tree/${branch}` : ""}`;
   const params = queryParams({ limit, offset, filter });
-  return client(token, circleHost).get<BuildSummaryResponse>(`${url}${params}`);
+  return client(token, circleHost, customHeaders).get<BuildSummaryResponse>(
+    `${url}${params}`
+  );
 }
 
 /**
@@ -79,8 +83,8 @@ export function getBuildSummaries(
 export function getFullBuild(
   token: string,
   buildNumber: number,
-  { circleHost, ...vcs }: GitInfo & CircleOptions
+  { circleHost, customHeaders, ...vcs }: GitInfo & CircleOptions
 ): Promise<FetchBuildResponse> {
   const url = `${createVcsUrl(vcs)}/${buildNumber}`;
-  return client(token, circleHost).get<FetchBuildResponse>(url);
+  return client(token, circleHost, customHeaders).get<FetchBuildResponse>(url);
 }

--- a/src/api/cache.ts
+++ b/src/api/cache.ts
@@ -19,8 +19,8 @@ import { client } from "../client";
  */
 export function clearCache(
   token: string,
-  { circleHost, ...vcs }: GitInfo & CircleOptions
+  { circleHost, customHeaders, ...vcs }: GitInfo & CircleOptions
 ): Promise<ClearCacheResponse> {
   const url = `${createVcsUrl(vcs)}/build-cache`;
-  return client(token, circleHost).delete(url);
+  return client(token, circleHost, customHeaders).delete(url);
 }

--- a/src/api/checkout-keys.ts
+++ b/src/api/checkout-keys.ts
@@ -22,9 +22,11 @@ import { createJsonHeader } from "../util";
  */
 export function getCheckoutKeys(
   token: string,
-  { circleHost, ...vcs }: GitInfo & CircleOptions
+  { circleHost, customHeaders, ...vcs }: GitInfo & CircleOptions
 ): Promise<CheckoutKeyResponse> {
-  return client(token, circleHost).get<CheckoutKeyResponse>(createUrl(vcs));
+  return client(token, circleHost, customHeaders).get<CheckoutKeyResponse>(
+    createUrl(vcs)
+  );
 }
 
 /**
@@ -42,9 +44,9 @@ export function getCheckoutKeys(
 export function createCheckoutKey(
   token: string,
   key: CheckoutKey,
-  { circleHost, ...vcs }: GitInfo & CircleOptions
+  { circleHost, customHeaders, ...vcs }: GitInfo & CircleOptions
 ): Promise<CheckoutKeyResponse> {
-  return client(token, circleHost).post<CheckoutKeyResponse>(
+  return client(token, circleHost, customHeaders).post<CheckoutKeyResponse>(
     createUrl(vcs),
     key,
     createJsonHeader()
@@ -66,9 +68,9 @@ export function createCheckoutKey(
 export function getCheckoutKey(
   token: string,
   fingerprint: string,
-  { circleHost, ...vcs }: GitInfo & CircleOptions
+  { circleHost, customHeaders, ...vcs }: GitInfo & CircleOptions
 ): Promise<CheckoutKeyResponse> {
-  return client(token, circleHost).get<CheckoutKeyResponse>(
+  return client(token, circleHost, customHeaders).get<CheckoutKeyResponse>(
     createUrl(vcs, fingerprint)
   );
 }
@@ -88,11 +90,11 @@ export function getCheckoutKey(
 export function deleteCheckoutKey(
   token: string,
   fingerprint: string,
-  { circleHost, ...vcs }: GitInfo & CircleOptions
+  { circleHost, customHeaders, ...vcs }: GitInfo & CircleOptions
 ): Promise<DeleteCheckoutKeyResponse> {
-  return client(token, circleHost).delete<DeleteCheckoutKeyResponse>(
-    createUrl(vcs, fingerprint)
-  );
+  return client(token, circleHost, customHeaders).delete<
+    DeleteCheckoutKeyResponse
+  >(createUrl(vcs, fingerprint));
 }
 
 /**

--- a/src/api/env.ts
+++ b/src/api/env.ts
@@ -26,9 +26,9 @@ import { createJsonHeader } from "../util";
  */
 export function listEnv(
   token: string,
-  { circleHost, ...vcs }: GitInfo & CircleOptions
+  { circleHost, customHeaders, ...vcs }: GitInfo & CircleOptions
 ): Promise<ListEnvVariablesResponse> {
-  return client(token, circleHost).get<ListEnvVariablesResponse>(
+  return client(token, circleHost, customHeaders).get<ListEnvVariablesResponse>(
     createUrl(vcs)
   );
 }
@@ -48,9 +48,9 @@ export function listEnv(
 export function addEnv(
   token: string,
   payload: EnvVariable,
-  { circleHost, ...vcs }: GitInfo & CircleOptions
+  { circleHost, customHeaders, ...vcs }: GitInfo & CircleOptions
 ): Promise<EnvVariableResponse> {
-  return client(token, circleHost).post<EnvVariableResponse>(
+  return client(token, circleHost, customHeaders).post<EnvVariableResponse>(
     createUrl(vcs),
     payload,
     createJsonHeader()
@@ -72,9 +72,9 @@ export function addEnv(
 export function getEnv(
   token: string,
   envName: string,
-  { circleHost, ...vcs }: GitInfo & CircleOptions
+  { circleHost, customHeaders, ...vcs }: GitInfo & CircleOptions
 ): Promise<EnvVariableResponse> {
-  return client(token, circleHost).get(createUrl(vcs, envName));
+  return client(token, circleHost, customHeaders).get(createUrl(vcs, envName));
 }
 
 /**
@@ -92,9 +92,11 @@ export function getEnv(
 export function deleteEnv(
   token: string,
   envName: string,
-  { circleHost, ...vcs }: GitInfo & CircleOptions
+  { circleHost, customHeaders, ...vcs }: GitInfo & CircleOptions
 ): Promise<DeleteEnvVarResponse> {
-  return client(token, circleHost).delete(createUrl(vcs, envName));
+  return client(token, circleHost, customHeaders).delete(
+    createUrl(vcs, envName)
+  );
 }
 
 /**

--- a/src/api/metadata.ts
+++ b/src/api/metadata.ts
@@ -21,8 +21,10 @@ import { client } from "../client";
 export function getTestMetadata(
   token: string,
   buildNumber: number,
-  { circleHost, ...vcs }: GitInfo & CircleOptions
+  { circleHost, customHeaders, ...vcs }: GitInfo & CircleOptions
 ): Promise<TestMetadataResponse> {
   const url = `${createVcsUrl(vcs)}/${buildNumber}/tests`;
-  return client(token, circleHost).get<TestMetadataResponse>(url);
+  return client(token, circleHost, customHeaders).get<TestMetadataResponse>(
+    url
+  );
 }

--- a/src/api/misc.ts
+++ b/src/api/misc.ts
@@ -27,10 +27,13 @@ export function addSSHKey(
   token: string,
   vcs: GitInfo,
   key: SSHKey,
-  { circleHost }: CircleOptions = {}
+  { circleHost, customHeaders }: CircleOptions = {}
 ): Promise<AddSSHKeyResponse> {
   const url = `${createVcsUrl(vcs)}/ssh-key`;
-  return client(token, circleHost).post<AddSSHKeyResponse>(url, key);
+  return client(token, circleHost, customHeaders).post<AddSSHKeyResponse>(
+    url,
+    key
+  );
 }
 
 /**
@@ -47,8 +50,11 @@ export function addSSHKey(
 export function addHerokuKey(
   token: string,
   key: HerokuKey,
-  { circleHost }: CircleOptions = {}
+  { circleHost, customHeaders }: CircleOptions = {}
 ): Promise<AddHerokuResponse> {
   const url = `${API_USER}/heroku-key`;
-  return client(token, circleHost).post<AddHerokuResponse>(url, key);
+  return client(token, circleHost, customHeaders).post<AddHerokuResponse>(
+    url,
+    key
+  );
 }

--- a/src/api/projects.ts
+++ b/src/api/projects.ts
@@ -15,9 +15,11 @@ import {
  */
 export function getAllProjects(
   token: string,
-  { circleHost }: CircleOptions = {}
+  { circleHost, customHeaders }: CircleOptions = {}
 ): Promise<AllProjectsResponse> {
-  return client(token, circleHost).get<AllProjectsResponse>(API_ALL_PROJECTS);
+  return client(token, circleHost, customHeaders).get<AllProjectsResponse>(
+    API_ALL_PROJECTS
+  );
 }
 
 /**
@@ -27,8 +29,10 @@ export function getAllProjects(
  */
 export function postFollowNewProject(
   token: string,
-  { vcs, circleHost }: GitRequiredRequest
+  { vcs, circleHost, customHeaders }: GitRequiredRequest
 ): Promise<FollowProjectResponse> {
   const url = `${createVcsUrl(vcs)}/follow`;
-  return client(token, circleHost).post<FollowProjectResponse>(url);
+  return client(token, circleHost, customHeaders).post<FollowProjectResponse>(
+    url
+  );
 }

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -8,7 +8,7 @@ import { client } from "../client";
  */
 export function getMe(
   token: string,
-  { circleHost }: CircleOptions = {}
+  { circleHost, customHeaders }: CircleOptions = {}
 ): Promise<MeResponse> {
-  return client(token, circleHost).get<MeResponse>(API_ME);
+  return client(token, circleHost, customHeaders).get<MeResponse>(API_ME);
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -90,8 +90,14 @@ export interface ClientFactory {
  * @param token CircleCI API token
  * @param circleHost Custom host address for CircleCI
  */
-export function client(token: string, circleHost: string = API_BASE) {
-  const baseOptions: AxiosRequestConfig = { baseURL: circleHost };
+export function client(
+  token: string,
+  circleHost: string = API_BASE,
+  headers?: any
+) {
+  const baseOptions: AxiosRequestConfig = headers
+    ? { headers, baseURL: circleHost }
+    : { baseURL: circleHost };
   const factory: ClientFactory = {
     get: async <T>(
       url: string,

--- a/src/types/lib.ts
+++ b/src/types/lib.ts
@@ -77,13 +77,13 @@ export interface FilterRequestOptions extends RequestOptions {
  * @property {string} [token] - CircleCI API key
  * @property {GitInfo} [vcs] - Git information required for project related endpoints
  * @property {Options} [options] - Extra query parameters for build endpoints
- * @property {string} circleHost - Override the default host for CircleCI [API_BASE]
+ * @property {string} [circleHost] - Override the default host for CircleCI [API_BASE]
+ * @property {any} [customHeaders] - Custom headers to be attached to each CircleCI request
  */
-export interface CircleRequest {
+export interface CircleRequest extends CircleOptions {
   token?: string;
   vcs?: GitInfo;
   options?: Options;
-  circleHost?: string;
 }
 
 /**
@@ -113,6 +113,7 @@ export interface FullRequest extends CircleRequest {
 
 export interface CircleOptions {
   circleHost?: string;
+  customHeaders?: any;
 }
 
 /**

--- a/test/api/actions.test.ts
+++ b/test/api/actions.test.ts
@@ -31,7 +31,7 @@ describe("API - Actions", () => {
         mock.__setResponse(response);
         const result = await circle.retry(5);
 
-        expect(mock.client).toBeCalledWith(TOKEN, undefined);
+        expect(mock.client).toBeCalledWith(TOKEN, undefined, undefined);
         expect(mock.__postMock).toBeCalledWith(
           "/project/github/test/repotest/5/retry"
         );
@@ -45,7 +45,7 @@ describe("API - Actions", () => {
           vcs: { type: GitType.BITBUCKET, repo: "square" }
         });
 
-        expect(mock.client).toBeCalledWith(TOKEN, undefined);
+        expect(mock.client).toBeCalledWith(TOKEN, undefined, undefined);
         expect(mock.__postMock).toBeCalledWith(
           "/project/bitbucket/test/square/5/retry"
         );
@@ -65,7 +65,7 @@ describe("API - Actions", () => {
         mock.__setResponse(response);
         const result = await circle.cancel(5);
 
-        expect(mock.client).toBeCalledWith(TOKEN, undefined);
+        expect(mock.client).toBeCalledWith(TOKEN, undefined, undefined);
         expect(mock.__postMock).toBeCalledWith(
           "/project/github/test/repotest/5/cancel"
         );
@@ -79,7 +79,7 @@ describe("API - Actions", () => {
           vcs: { type: GitType.BITBUCKET, repo: "square" }
         });
 
-        expect(mock.client).toBeCalledWith(TOKEN, undefined);
+        expect(mock.client).toBeCalledWith(TOKEN, undefined, undefined);
         expect(mock.__postMock).toBeCalledWith(
           "/project/bitbucket/test/square/5/cancel"
         );
@@ -94,7 +94,7 @@ describe("API - Actions", () => {
           vcs: { type: GitType.BITBUCKET, repo: "square", owner: "bar" }
         }).cancel(5);
 
-        expect(mock.client).toBeCalledWith(TOKEN, "foo.bar/api");
+        expect(mock.client).toBeCalledWith(TOKEN, "foo.bar/api", undefined);
       });
     });
   });
@@ -110,7 +110,7 @@ describe("API - Actions", () => {
       mock.__setResponse(response);
       const result = await circle.triggerBuild();
 
-      expect(mock.client).toBeCalledWith(TOKEN, undefined);
+      expect(mock.client).toBeCalledWith(TOKEN, undefined, undefined);
       expect(mock.__postMock).toBeCalledWith(
         "/project/github/test/repotest",
         expect.any(Object)
@@ -126,12 +126,27 @@ describe("API - Actions", () => {
         options: { branch: "develop" }
       });
 
-      expect(mock.client).toBeCalledWith(TOKEN, undefined);
+      expect(mock.client).toBeCalledWith(TOKEN, undefined, undefined);
       expect(mock.__postMock).toBeCalledWith(
         "/project/bitbucket/test/square/tree/develop",
         expect.any(Object)
       );
       expect(result).toEqual(response);
+    });
+
+    it("should use the custom headers", async () => {
+      mock.__setResponse(response);
+      await postTriggerNewBuild(
+        TOKEN,
+        {
+          vcs: { owner: "test", repo: "repotest" },
+          customHeaders: { someHeader: "some_header_value" },
+        }
+      );
+
+      expect(mock.client).toBeCalledWith(TOKEN, undefined, {
+        someHeader: "some_header_value",
+      });
     });
   });
 
@@ -146,7 +161,7 @@ describe("API - Actions", () => {
       mock.__setResponse(response);
       const result = await circle.triggerBuildFor();
 
-      expect(mock.client).toBeCalledWith(TOKEN, undefined);
+      expect(mock.client).toBeCalledWith(TOKEN, undefined, undefined);
       expect(mock.__postMock).toBeCalledWith(
         "/project/github/test/repotest/tree/master",
         expect.any(Object)
@@ -162,7 +177,7 @@ describe("API - Actions", () => {
         options: { newBuildOptions: { tag: "foo" } }
       });
 
-      expect(mock.client).toBeCalledWith(TOKEN, undefined);
+      expect(mock.client).toBeCalledWith(TOKEN, undefined, undefined);
       expect(mock.__postMock).toBeCalledWith(
         "/project/bitbucket/test/square/tree/feat",
         expect.objectContaining({

--- a/test/api/artifacts.test.ts
+++ b/test/api/artifacts.test.ts
@@ -53,7 +53,7 @@ describe("API - Artifacts", () => {
       circleHost: "foo.bar/api"
     }).artifacts(42);
 
-    expect(mock.client).toBeCalledWith(TOKEN, "foo.bar/api");
+    expect(mock.client).toBeCalledWith(TOKEN, "foo.bar/api", undefined);
   });
 
   describe("Latest Artifacts", () => {
@@ -63,7 +63,7 @@ describe("API - Artifacts", () => {
         vcs: { owner: "t", repo: "r" }
       });
 
-      expect(mock.client).toBeCalledWith(TOKEN, undefined);
+      expect(mock.client).toBeCalledWith(TOKEN, undefined, undefined);
       expect(mock.__getMock).toBeCalledWith(
         expect.stringContaining("t/r/latest/artifacts")
       );
@@ -76,7 +76,7 @@ describe("API - Artifacts", () => {
         vcs: { owner: "test2" }
       });
 
-      expect(mock.client).toBeCalledWith(TOKEN, undefined);
+      expect(mock.client).toBeCalledWith(TOKEN, undefined, undefined);
       expect(mock.__getMock).toBeCalledWith(
         expect.stringContaining("test2/proj/latest/artifacts")
       );
@@ -90,7 +90,7 @@ describe("API - Artifacts", () => {
         options: { branch: "develop" }
       });
 
-      expect(mock.client).toBeCalledWith(TOKEN, undefined);
+      expect(mock.client).toBeCalledWith(TOKEN, undefined, undefined);
       expect(mock.__getMock).toBeCalledWith(
         expect.stringContaining("branch=develop")
       );
@@ -105,7 +105,22 @@ describe("API - Artifacts", () => {
         circleHost: "foo.bar/api"
       }).latestArtifacts();
 
-      expect(mock.client).toBeCalledWith(TOKEN, "foo.bar/api");
+      expect(mock.client).toBeCalledWith(TOKEN, "foo.bar/api", undefined);
+    });
+
+    it("should use the custom headers", async () => {
+      mock.__setResponse(artifact);
+      await getLatestArtifacts(
+        TOKEN,
+        {
+          vcs: { owner: "test", repo: "proj" },
+          customHeaders: { someHeader: "some_header_value" },
+        }
+      );
+
+      expect(mock.client).toBeCalledWith(TOKEN, undefined, {
+        someHeader: "some_header_value",
+      });
     });
 
     it("should throw an error if request fails", async () => {

--- a/test/api/builds.test.ts
+++ b/test/api/builds.test.ts
@@ -63,7 +63,18 @@ describe("API - Builds", () => {
         circleHost: "foo.bar/api",
       }).recentBuilds();
 
-      expect(mock.client).toBeCalledWith(TOKEN, "foo.bar/api");
+      expect(mock.client).toBeCalledWith(TOKEN, "foo.bar/api", undefined);
+    });
+
+    it("should use the custom headers", async () => {
+      mock.__setResponse(response);
+      await getRecentBuilds(TOKEN, {
+        customHeaders: { someHeader: "some_header_value" }
+      });
+
+      expect(mock.client).toBeCalledWith(TOKEN, undefined, {
+        someHeader: "some_header_value",
+      });
     });
   });
 
@@ -84,7 +95,7 @@ describe("API - Builds", () => {
         circleHost: "foo.bar/api",
       }).builds();
 
-      expect(mock.client).toBeCalledWith(TOKEN, "foo.bar/api");
+      expect(mock.client).toBeCalledWith(TOKEN, "foo.bar/api", undefined);
     });
 
     it("should fetch latest builds with options", async () => {
@@ -132,7 +143,7 @@ describe("API - Builds", () => {
         circleHost: "foo.bar/api",
       }).buildsFor();
 
-      expect(mock.client).toBeCalledWith(TOKEN, "foo.bar/api");
+      expect(mock.client).toBeCalledWith(TOKEN, "foo.bar/api", undefined);
     });
 
     it("should handle no options", async () => {
@@ -143,6 +154,21 @@ describe("API - Builds", () => {
 
       expect(mock.__getMock).toBeCalledWith("/project/github/foo/bar");
       expect(result).toEqual(response);
+    });
+
+    it("should use the custom headers", async () => {
+      mock.__setResponse(response);
+      await getBuildSummaries(
+        TOKEN,
+        {
+          vcs: { owner: "foo", repo: "bar" },
+          customHeaders: { someHeader: "some_header_value", },
+        }
+      );
+
+      expect(mock.client).toBeCalledWith(TOKEN, undefined, {
+        someHeader: "some_header_value",
+      });
     });
   });
 
@@ -170,7 +196,7 @@ describe("API - Builds", () => {
         circleHost: "foo.bar/api",
       }).build(1);
 
-      expect(mock.client).toBeCalledWith(TOKEN, "foo.bar/api");
+      expect(mock.client).toBeCalledWith(TOKEN, "foo.bar/api", undefined);
     });
   });
 });

--- a/test/api/projects.test.ts
+++ b/test/api/projects.test.ts
@@ -34,7 +34,7 @@ describe("API - Projects", () => {
       mock.__setResponse(response);
       const result = await circle.projects();
 
-      expect(mock.client).toBeCalledWith(TOKEN, undefined);
+      expect(mock.client).toBeCalledWith(TOKEN, undefined, undefined);
       expect(mock.__getMock).toBeCalledWith(API_ALL_PROJECTS);
       expect(result).toEqual(response);
     });
@@ -50,7 +50,7 @@ describe("API - Projects", () => {
       mock.__setResponse(response);
       await getAllProjects(TOKEN);
 
-      expect(mock.client).toBeCalledWith(TOKEN, undefined);
+      expect(mock.client).toBeCalledWith(TOKEN, undefined, undefined);
     });
 
     it("should use a custom circleci host", async () => {
@@ -61,7 +61,7 @@ describe("API - Projects", () => {
         circleHost: "foo.bar/api"
       }).projects();
 
-      expect(mock.client).toBeCalledWith(TOKEN, "foo.bar/api");
+      expect(mock.client).toBeCalledWith(TOKEN, "foo.bar/api", undefined);
     });
   });
 
@@ -82,7 +82,7 @@ describe("API - Projects", () => {
         }
       });
 
-      expect(mock.client).toBeCalledWith(TOKEN, undefined);
+      expect(mock.client).toBeCalledWith(TOKEN, undefined, undefined);
       expect(mock.__postMock).toBeCalledWith(
         expect.stringContaining("johnsmith/tinker/follow")
       );
@@ -103,7 +103,7 @@ describe("API - Projects", () => {
         circleHost: "foo.bar/api"
       }).followProject({} as any);
 
-      expect(mock.client).toBeCalledWith(TOKEN, "foo.bar/api");
+      expect(mock.client).toBeCalledWith(TOKEN, "foo.bar/api", undefined);
     });
   });
 });

--- a/test/api/user.test.ts
+++ b/test/api/user.test.ts
@@ -25,7 +25,7 @@ describe("API - Me", () => {
     mock.__setResponse(me);
     const result = await circle.me();
 
-    expect(mock.client).toBeCalledWith(TOKEN, undefined);
+    expect(mock.client).toBeCalledWith(TOKEN, undefined, undefined);
     expect(mock.__getMock).toBeCalledWith(API_ME);
     expect(result).toEqual(me);
   });
@@ -41,7 +41,7 @@ describe("API - Me", () => {
     mock.__setResponse(me);
     await getMe(TOKEN);
 
-    expect(mock.client).toBeCalledWith(TOKEN, undefined);
+    expect(mock.client).toBeCalledWith(TOKEN, undefined, undefined);
   });
 
   it("should use a custom circleci host", async () => {
@@ -51,6 +51,6 @@ describe("API - Me", () => {
       circleHost: "foo.bar/api"
     }).projects();
 
-    expect(mock.client).toBeCalledWith(TOKEN, "foo.bar/api");
+    expect(mock.client).toBeCalledWith(TOKEN, "foo.bar/api", undefined);
   });
 });

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -63,6 +63,18 @@ describe("Client", () => {
       );
     });
 
+    it("should use custom headers", () => {
+      client(TOKEN, undefined, { someHeader: "some_header_value" })
+        .get(URL)
+        .catch(jest.fn());
+      expect(mockAxios.get).toBeCalledWith(
+        URL_WITH_TOKEN,
+        expect.objectContaining({
+          headers: expect.objectContaining({ someHeader: "some_header_value" }),
+        })
+      );
+    });
+
     it("should use options", () => {
       client(TOKEN).post(URL, "test", { timeout: 1000 }).catch(jest.fn());
       expect(mockAxios.post).toBeCalledWith(


### PR DESCRIPTION
## Background

**circleci-api** library is used in corresponding [backstage.io](backstage.io) plugin:
https://github.com/backstage/backstage/blob/master/plugins/circleci/src/api/CircleCIApi.ts#L28

Backstage plugins communicate to 3-rd party services (incl. Circleci) via proxy (this e.g. allows to add backstage own auth):
https://backstage.io/docs/plugins/proxying

Communication to Circleci API thought proxy may require additional custom headers. Looks like with current **circleci-api** implementation there is no good way to intercept library requests as is to add custom headers on top.

## Updates

PR adds ability to pass custom headers to all functions that communicate to Circleci API.
There are no breaking changes because ~additional custom headers param is optional~ signatures are not changed, new custom headers field is optional.
Custom headers can also be useful for other use cases (e.g. monitoring, tracing. etc.).